### PR TITLE
DT-2222 Add recall to smoke test

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/dpssmoketest/service/PoeSmokeTestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/dpssmoketest/service/PoeSmokeTestService.kt
@@ -3,23 +3,35 @@ package uk.gov.justice.digital.hmpps.dpssmoketest.service
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
 import uk.gov.justice.digital.hmpps.dpssmoketest.resource.SmokeTestResource.TestStatus
+import uk.gov.justice.digital.hmpps.dpssmoketest.resource.SmokeTestResource.TestStatus.TestProgress.COMPLETE
+import uk.gov.justice.digital.hmpps.dpssmoketest.resource.SmokeTestResource.TestStatus.TestProgress.INCOMPLETE
+import uk.gov.justice.digital.hmpps.dpssmoketest.resource.SmokeTestResource.TestStatus.TestProgress.SUCCESS
 
 @Service
 class PoeSmokeTestService(
-  private val prisonService: PrisonService
+  private val prisonService: PrisonService,
+  private val queueService: QueueService
+
 ) {
   fun runSmokeTest(testProfile: PoeTestParameters): Flux<TestStatus> {
-    return Flux.concat(
-      Flux.just(TestStatus("Will release prisoner ${testProfile.nomsNumber}", TestStatus.TestProgress.INCOMPLETE)),
-      // Trigger test by releasing prisoner
-      Flux.from(prisonService.triggerPoeReleaseTest(testProfile.nomsNumber)),
-      // Check for hmpps domain release event
-      Flux.from(prisonService.waitForEventToBeProduced(testProfile.nomsNumber)),
 
-      // Trigger test by recalling prisoner
-      // Flux.from(prisonService.triggerPoeRecallTest(it.nomsNumber)),
-      // Check for hmpps domain recall event
-      // prisonService.waitForEventToBeProduced(testProfile.nomsNumber),
+    // TODO (Should we ensure prisoner is in prison before attempting to release them?)
+    queueService.purgeQueue()
+
+    return Flux.concat(
+      Flux.just(TestStatus("Will release prisoner ${testProfile.nomsNumber}", INCOMPLETE)),
+      Flux.from(prisonService.triggerPoeReleaseTest(testProfile.nomsNumber)),
+      Flux.from(
+        queueService.waitForEventToBeProduced(
+          "prison-offender-events.prisoner.released", testProfile.nomsNumber,
+          COMPLETE
+        )
+      ),
+      Flux.just(TestStatus("Will recall prisoner ${testProfile.nomsNumber}", INCOMPLETE)),
+      Flux.from(prisonService.triggerPoeRecallTest(testProfile.nomsNumber)),
+      Flux.from(queueService.waitForEventToBeProduced("prison-offender-events.prisoner.received", testProfile.nomsNumber, SUCCESS)),
     ).takeUntil(TestStatus::hasResult)
+
+    // TODO Question->shall we delete the queue?
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/dpssmoketest/service/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/dpssmoketest/service/PrisonService.kt
@@ -1,27 +1,20 @@
 package uk.gov.justice.digital.hmpps.dpssmoketest.service
 
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders.CONTENT_TYPE
 import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
-import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.dpssmoketest.resource.SmokeTestResource.TestStatus
 import uk.gov.justice.digital.hmpps.dpssmoketest.resource.SmokeTestResource.TestStatus.TestProgress.FAIL
-import uk.gov.justice.digital.hmpps.dpssmoketest.resource.SmokeTestResource.TestStatus.TestProgress.SUCCESS
-import java.time.Duration
 
 @Service
 class PrisonService(
-  @Value("\${test.maxLengthSeconds}") private val testMaxLengthSeconds: Long,
-  @Value("\${test.resultPollMs}") private val testResultPollMs: Long,
   @Qualifier("prisonApiWebClient") private val webClient: WebClient
 ) {
-
   fun triggerPtpuTest(nomsNumber: String): Mono<TestStatus> {
 
     fun failOnNotFound(): Mono<out TestStatus> =
@@ -82,7 +75,6 @@ class PrisonService(
 
     return webClient.put()
       .uri("/api/smoketest/offenders/{nomsNumber}/release", nomsNumber)
-      .contentType(MediaType.APPLICATION_JSON)
       .retrieve()
       .toBodilessEntity()
       .map { TestStatus("Triggered test for $nomsNumber") }
@@ -90,13 +82,20 @@ class PrisonService(
       .onErrorResume(::failOnError)
   }
 
-  fun waitForEventToBeProduced(nomsNumber: String): Flux<TestStatus> =
-    Flux.interval(Duration.ofMillis(testResultPollMs))
-      .take(Duration.ofSeconds(testMaxLengthSeconds))
-      .flatMap { checkEventProduced(nomsNumber) }
-      .takeUntil(TestStatus::testComplete)
+  fun triggerPoeRecallTest(nomsNumber: String): Mono<TestStatus> {
 
-  // TODO(add call to check event created - may not be in prison api)
-  fun checkEventProduced(nomsNumber: String): Mono<TestStatus> =
-    Mono.just(TestStatus("Test for offender $nomsNumber released event finished successfully", SUCCESS))
+    fun failOnNotFound(): Mono<out TestStatus> =
+      Mono.just(TestStatus("Trigger test failed. The offender $nomsNumber can not be found", FAIL))
+
+    fun failOnError(exception: Throwable): Mono<out TestStatus> =
+      Mono.just(TestStatus("Trigger for $nomsNumber failed due to ${exception.message}", FAIL))
+
+    return webClient.put()
+      .uri("/api/smoketest/offenders/{nomsNumber}/recall", nomsNumber)
+      .retrieve()
+      .toBodilessEntity()
+      .map { TestStatus("Triggered test for $nomsNumber") }
+      .onErrorResume(WebClientResponseException.NotFound::class.java) { failOnNotFound() }
+      .onErrorResume(::failOnError)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/dpssmoketest/service/QueueService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/dpssmoketest/service/QueueService.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.dpssmoketest.service
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.dpssmoketest.resource.SmokeTestResource.TestStatus
+import uk.gov.justice.digital.hmpps.dpssmoketest.resource.SmokeTestResource.TestStatus.TestProgress
+import uk.gov.justice.digital.hmpps.dpssmoketest.resource.SmokeTestResource.TestStatus.TestProgress.FAIL
+import java.time.Duration
+
+@Service
+class QueueService(
+  @Value("\${test.maxLengthSeconds}") private val testMaxLengthSeconds: Long,
+  @Value("\${test.resultPollMs}") private val testResultPollMs: Long
+) {
+
+  fun waitForEventToBeProduced(eventType: String, nomsNumber: String, finalStatus: TestProgress): Flux<TestStatus> =
+    Flux.interval(Duration.ofMillis(testResultPollMs))
+      .take(Duration.ofSeconds(testMaxLengthSeconds))
+      .flatMap { checkEventProduced(eventType, nomsNumber, finalStatus) }
+      .takeUntil(TestStatus::testComplete)
+
+  fun checkEventProduced(eventType: String, nomsNumber: String, finalStatus: TestProgress): Mono<TestStatus> {
+
+    fun failOnError(exception: Throwable): Mono<out TestStatus> =
+      Mono.just(
+        TestStatus("Check $eventType event produced $nomsNumber failed due to ${exception.message}", FAIL)
+      )
+
+    return Mono.just(checkForEvent(eventType, nomsNumber))
+      .map {
+        if (it)
+          TestStatus("Test for offender $nomsNumber $eventType event finished successfully", finalStatus)
+        else
+          TestStatus("Still waiting for offender $nomsNumber $eventType event")
+      }
+      .onErrorResume(::failOnError)
+  }
+
+  fun checkForEvent(eventTypeRequired: String, nomsNumber: String): Boolean {
+    return true
+  }
+
+  fun purgeQueue() {
+    return
+  }
+}


### PR DESCRIPTION
I have pulled the recall code out into this PR as the queue work is holding up the final PR.
I have added the new QueueService - but it is just a placeholder for when the queue code is in and working.  As can be seen, it just returns true to acknowledge the event is produced.  Adding in the recall ensures the prisoner status is returned to being in prison - ensuring running multiple smoke tests will complete successfully.