### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/dps-smoketest/Chart.yaml
+++ b/helm_deploy/dps-smoketest/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.1
 
 dependencies:
   - name: generic-service
-    version: 2.8
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3

--- a/helm_deploy/dps-smoketest/values.yaml
+++ b/helm_deploy/dps-smoketest/values.yaml
@@ -1,4 +1,3 @@
----
 # Values here are the same across all environments
 
 generic-service:
@@ -8,7 +7,7 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/dps-smoketest
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
@@ -39,12 +38,8 @@ generic-service:
       HMPPS_SQS_QUEUES_HMPPSEVENTQUEUE_QUEUE_NAME: "sqs_queue_name"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
+    groups:
+      - internal
 
 generic-prometheus-alerts:
   targetApplication: dps-smoketest


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/dps-smoketest/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `6 => 0 (6 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- global-protect
  

- petty-france-wifi
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  
